### PR TITLE
Add simple playback speed chrome extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# CanDoYouTube
+# CanDoYouTube Extension
+
+This repository contains a simple Chrome extension that lets you control video playback speed with keyboard shortcuts.
+
+## Usage
+
+Load the `CanDoYouTube` folder as an unpacked extension in Chrome and navigate to a supported site such as YouTube. Use the following keys:
+
+- `a` – decrease speed by 0.25×
+- `s` – increase speed by 0.25×
+- `q` – reset speed to 1×
+- `w` – set speed to a custom value (default 4×)
+
+Open the extension options to configure the value for the `w` key and manage the list of allowed sites. Settings are stored using `chrome.storage.sync` so they persist between browser sessions.
+
+## Files
+
+- `manifest.json` – Chrome extension manifest
+- `content.js` – content script that handles keyboard input
+- `options.html` / `options.js` – simple options page
+- `icons/` – extension icons in SVG format
+
+

--- a/content.js
+++ b/content.js
@@ -1,0 +1,62 @@
+(function() {
+  const DEFAULT_SITES = ['youtube.com'];
+  const DEFAULT_W_SPEED = 4;
+
+  function getSettings() {
+    return new Promise(resolve => {
+      chrome.storage.sync.get(['allowedSites', 'wSpeed'], (data) => {
+        resolve({
+          allowedSites: data.allowedSites || DEFAULT_SITES,
+          wSpeed: typeof data.wSpeed === 'number' ? data.wSpeed : DEFAULT_W_SPEED
+        });
+      });
+    });
+  }
+
+  function isAllowed(hostname, sites) {
+    return sites.some(site => hostname === site || hostname.endsWith('.' + site));
+  }
+
+  function adjustVideo(rateSetter) {
+    const video = document.querySelector('video');
+    if (video) {
+      rateSetter(video);
+    }
+  }
+
+  function init() {
+    getSettings().then(({allowedSites, wSpeed}) => {
+      if (!isAllowed(location.hostname, allowedSites)) {
+        return;
+      }
+
+      document.addEventListener('keydown', (e) => {
+        if (e.target && (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.isContentEditable)) {
+          return; // ignore typing in inputs
+        }
+        switch (e.key) {
+          case 'a':
+            adjustVideo(video => {
+              video.playbackRate = Math.max(0.25, Math.round((video.playbackRate - 0.25)*100)/100);
+            });
+            break;
+          case 's':
+            adjustVideo(video => {
+              video.playbackRate = Math.round((video.playbackRate + 0.25)*100)/100;
+            });
+            break;
+          case 'q':
+            adjustVideo(video => { video.playbackRate = 1; });
+            break;
+          case 'w':
+            adjustVideo(video => { video.playbackRate = wSpeed; });
+            break;
+          default:
+            return;
+        }
+      });
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', init);
+})();

--- a/icons/icon128.svg
+++ b/icons/icon128.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="16" ry="16" fill="#ff0000"/>
+  <polygon points="56,32 96,64 56,96" fill="#ffffff"/>
+</svg>

--- a/icons/icon48.svg
+++ b/icons/icon48.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  <rect width="48" height="48" rx="8" ry="8" fill="#ff0000"/>
+  <polygon points="20,14 34,24 20,34" fill="#ffffff"/>
+</svg>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,20 @@
+{
+  "manifest_version": 3,
+  "name": "Speed Control for Video",
+  "version": "1.0",
+  "description": "Adjust playback speed with keyboard shortcuts on supported sites.",
+  "icons": {
+    "48": "icons/icon48.svg",
+    "128": "icons/icon128.svg"
+  },
+  "permissions": ["storage"],
+  "host_permissions": ["*://*/*"],
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "run_at": "document_end"
+    }
+  ],
+  "options_page": "options.html"
+}

--- a/options.html
+++ b/options.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Speed Control Options</title>
+  <style>
+    body { font-family: Arial, sans-serif; padding: 10px; }
+    label { display: block; margin-top: 10px; }
+    input[type="text"] { width: 200px; }
+  </style>
+</head>
+<body>
+  <h1>Playback Speed Settings</h1>
+  <label>
+    W key speed:
+    <input type="number" id="wSpeed" step="0.25" min="0.25" />
+  </label>
+  <label>
+    Allowed sites (comma separated domains):
+    <input type="text" id="sites" />
+  </label>
+  <button id="save">Save</button>
+  <div id="status"></div>
+  <script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,25 @@
+const DEFAULT_SITES = ['youtube.com'];
+const DEFAULT_W_SPEED = 4;
+
+function loadOptions() {
+  chrome.storage.sync.get(['allowedSites', 'wSpeed'], (data) => {
+    document.getElementById('wSpeed').value = typeof data.wSpeed === 'number' ? data.wSpeed : DEFAULT_W_SPEED;
+    const sites = (data.allowedSites || DEFAULT_SITES).join(', ');
+    document.getElementById('sites').value = sites;
+  });
+}
+
+function saveOptions() {
+  const wSpeed = parseFloat(document.getElementById('wSpeed').value) || DEFAULT_W_SPEED;
+  const sitesInput = document.getElementById('sites').value.trim();
+  const allowedSites = sitesInput ? sitesInput.split(/\s*,\s*/).filter(Boolean) : DEFAULT_SITES;
+
+  chrome.storage.sync.set({ wSpeed, allowedSites }, () => {
+    const status = document.getElementById('status');
+    status.textContent = 'Options saved.';
+    setTimeout(() => { status.textContent = ''; }, 1000);
+  });
+}
+
+document.getElementById('save').addEventListener('click', saveOptions);
+document.addEventListener('DOMContentLoaded', loadOptions);


### PR DESCRIPTION
## Summary
- build a Chrome extension for controlling video playback speed
- add configurable options page
- ship icons
- document how to use the extension
- replace binary icon PNGs with SVG files

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6843edf07d5083259c03b00d5d6a49ce