### PR TITLE
Improve ad skip detection and manual skip key

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Load the `CanDoYouTube` folder as an unpacked extension in Chrome and navigate t
 - `s` – increase speed by 0.25×
 - `q` – reset speed to 1×
 - `w` – set speed to a custom value (default 4×)
-- Skip Ads – on YouTube the extension automatically clicks the "Skip" button whenever it appears
+- `e` – skip ads when the Skip button is available
+- Skip Ads – on YouTube the extension automatically clicks the "Skip" button whenever it appears and listens for new variations of the button
 
 Whenever you adjust the rate, a small overlay briefly shows the current
 playback speed on the page so you can confirm the setting. Debug logs are

--- a/content.js
+++ b/content.js
@@ -53,16 +53,39 @@
     }, 1000);
   }
 
+  function findSkipButton() {
+    const selectors = [
+      '.ytp-skip-ad-button',
+      '.ytp-ad-skip-button',
+      '[id*="skip" i]',
+      '[class*="skip" i]',
+      '[aria-label*="skip" i]'
+    ];
+    const elements = document.querySelectorAll(selectors.join(','));
+    for (const el of elements) {
+      if (el.offsetParent === null) continue; // ignore hidden elements
+      const btn = el.tagName === 'BUTTON' ? el : el.closest('button');
+      if (btn) return btn;
+    }
+    return null;
+  }
+
+  function clickSkipButton() {
+    const btn = findSkipButton();
+    if (btn) {
+      btn.click();
+      return true;
+    }
+    return false;
+  }
+
   function setupAdSkip() {
     if (!location.hostname.includes('youtube.com')) {
       return;
     }
-    setInterval(() => {
-      const skipBtn = document.querySelector('.ytp-skip-ad-button, .ytp-ad-skip-button');
-      if (skipBtn) {
-        skipBtn.click();
-      }
-    }, 1000);
+    const observer = new MutationObserver(clickSkipButton);
+    observer.observe(document, { childList: true, subtree: true });
+    setInterval(clickSkipButton, 1000);
   }
 
   function init() {
@@ -94,6 +117,9 @@
             break;
           case 'w':
             adjustVideo(video => { video.playbackRate = wSpeed; });
+            break;
+          case 'e':
+            clickSkipButton();
             break;
           default:
             return;


### PR DESCRIPTION
## Summary
- detect more variations of YouTube Skip buttons
- observe DOM for skip buttons and fall back to interval check
- add `e` key binding to manually skip ads
- document new key and improved skip feature in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6843feba7fa08325957e499ea6a3f05d