### PR TITLE
Improve reliability of ad speed logic

### DIFF
--- a/content.js
+++ b/content.js
@@ -92,27 +92,41 @@
     if (!location.hostname.includes('youtube.com')) {
       return;
     }
-    const player = document.querySelector('.html5-video-player');
-    const video = document.querySelector('video');
-    if (!player || !video) {
-      return;
-    }
-    let lastState = player.classList.contains('ad-showing');
-    const update = () => {
-      const isAd = player.classList.contains('ad-showing');
-      if (isAd !== lastState) {
-        lastState = isAd;
-        if (isAd) {
-          video.playbackRate = 2;
-        } else {
-          video.playbackRate = 1;
-        }
-        showSpeedIndicator(video.playbackRate);
+
+    const trySetup = () => {
+      const player = document.querySelector('.html5-video-player');
+      const video = document.querySelector('video');
+      if (!player || !video) {
+        return false;
       }
+
+      let lastState = player.classList.contains('ad-showing');
+      const update = () => {
+        const isAd = player.classList.contains('ad-showing');
+        if (isAd !== lastState) {
+          lastState = isAd;
+          if (isAd) {
+            video.playbackRate = 2;
+          } else {
+            video.playbackRate = 1;
+          }
+          showSpeedIndicator(video.playbackRate);
+        }
+      };
+
+      new MutationObserver(update).observe(player, { attributes: true, attributeFilter: ['class'] });
+      setInterval(update, 1000);
+      update();
+      return true;
     };
-    new MutationObserver(update).observe(player, { attributes: true, attributeFilter: ['class'] });
-    setInterval(update, 1000);
-    update();
+
+    if (!trySetup()) {
+      const interval = setInterval(() => {
+        if (trySetup()) {
+          clearInterval(interval);
+        }
+      }, 1000);
+    }
   }
 
   function init() {


### PR DESCRIPTION
## Summary
- ensure `setupAdSpeed` waits for the YouTube player to exist before attaching observers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68440245ab4083258a791a863233e572