### PR TITLE
Add ad delay option & debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Whenever you adjust the rate, a small overlay briefly shows the current
 playback speed on the page so you can confirm the setting. Debug logs are
 also written to the browser console when keys are pressed.
 
-Open the extension options to configure the value for the `w` key and manage the list of allowed sites. Settings are stored using `chrome.storage.sync` so they persist between browser sessions.
+Open the extension options to configure the value for the `w` key, set how long the extension waits before speeding up ads, and manage the list of allowed sites. Settings are stored using `chrome.storage.sync` so they persist between browser sessions.
 
 ## Files
 

--- a/options.html
+++ b/options.html
@@ -16,6 +16,10 @@
     <input type="number" id="wSpeed" step="0.25" min="0.25" />
   </label>
   <label>
+    Delay before speeding up ads (seconds):
+    <input type="number" id="adDelay" step="0.1" min="0" />
+  </label>
+  <label>
     Allowed sites (comma separated domains):
     <input type="text" id="sites" />
   </label>

--- a/options.js
+++ b/options.js
@@ -1,20 +1,23 @@
 const DEFAULT_SITES = ['youtube.com'];
 const DEFAULT_W_SPEED = 4;
+const DEFAULT_AD_DELAY = 2;
 
 function loadOptions() {
-  chrome.storage.sync.get(['allowedSites', 'wSpeed'], (data) => {
+  chrome.storage.sync.get(['allowedSites', 'wSpeed', 'adDelay'], (data) => {
     document.getElementById('wSpeed').value = typeof data.wSpeed === 'number' ? data.wSpeed : DEFAULT_W_SPEED;
     const sites = (data.allowedSites || DEFAULT_SITES).join(', ');
     document.getElementById('sites').value = sites;
+    document.getElementById('adDelay').value = typeof data.adDelay === 'number' ? data.adDelay : DEFAULT_AD_DELAY;
   });
 }
 
 function saveOptions() {
   const wSpeed = parseFloat(document.getElementById('wSpeed').value) || DEFAULT_W_SPEED;
+  const adDelay = parseFloat(document.getElementById('adDelay').value) || DEFAULT_AD_DELAY;
   const sitesInput = document.getElementById('sites').value.trim();
   const allowedSites = sitesInput ? sitesInput.split(/\s*,\s*/).filter(Boolean) : DEFAULT_SITES;
 
-  chrome.storage.sync.set({ wSpeed, allowedSites }, () => {
+  chrome.storage.sync.set({ wSpeed, allowedSites, adDelay }, () => {
     const status = document.getElementById('status');
     status.textContent = 'Options saved.';
     setTimeout(() => { status.textContent = ''; }, 1000);


### PR DESCRIPTION
## Summary
- add UI for ad speed delay option
- persist adDelay setting in extension storage
- make ad speedup wait delay configurable
- add debug logging around skip button logic
- document new feature in README

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684407cde4308325b8ab6ea1b3a64a88