### PR TITLE
Improve skip button handling and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,13 @@ Load the `CanDoYouTube` folder as an unpacked extension in Chrome and navigate t
 - `s` – increase speed by 0.25×
 - `q` – reset speed to 1×
 - `w` – set speed to a custom value (default 4×)
-- `e` – skip ads when the Skip button is available
-- Skip Ads – on YouTube the extension automatically clicks the "Skip" button whenever it appears and listens for new variations of the button
+- `e` – skip ads when the Skip button is available (also moves a simulated mouse pointer to the button)
+- Skip Ads – on YouTube the extension automatically moves a simulated pointer to the "Skip" button and clicks it whenever it appears, listening for new variations of the button
 
 Whenever you adjust the rate, a small overlay briefly shows the current
-playback speed on the page so you can confirm the setting. Debug logs are
-also written to the browser console when keys are pressed.
+playback speed on the page so you can confirm the setting. Detailed debug logs
+are also written to the browser console when keys are pressed or when the
+extension searches for and interacts with the Skip button.
 
 Open the extension options to configure the value for the `w` key, set how long the extension waits before speeding up ads, and manage the list of allowed sites. Settings are stored using `chrome.storage.sync` so they persist between browser sessions.
 


### PR DESCRIPTION
## Summary
- move a simulated cursor to the skip button before clicking
- add extensive debug logging around skip button search and key handling
- document skip button improvements in code comments
- update README to mention new behaviour and logging

## Testing
- `node --check content.js`

------
https://chatgpt.com/codex/tasks/task_e_68440e4983ac8325b7fb4f8d9c166963