### PR TITLE
Fix ad-skip loop when no video present

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Load the `CanDoYouTube` folder as an unpacked extension in Chrome and navigate t
 - `q` – reset speed to 1×
 - `w` – set speed to a custom value (default 4×)
 - `e` – skip ads when the Skip button is available (also moves a simulated mouse pointer to the button)
-- Skip Ads – on YouTube the extension automatically moves a simulated pointer to the "Skip" button and clicks it whenever it appears, listening for new variations of the button
+- Skip Ads – on YouTube the extension automatically moves a simulated pointer to the "Skip" button and clicks it whenever it appears. The ad-skipping logic now waits until a video element is present before activating so the home page no longer triggers continuous scanning.
 
 Whenever you adjust the rate, a small overlay briefly shows the current
 playback speed on the page so you can confirm the setting. Detailed debug logs

--- a/content.js
+++ b/content.js
@@ -124,6 +124,12 @@
   }
 
   function clickSkipButton() {
+    const player = document.querySelector('.html5-video-player');
+    const video = document.querySelector('video');
+    if (!player || !video) {
+      return false;
+    }
+
     const btn = findSkipButton();
     if (btn) {
       console.debug('Skip button found, moving mouse and attempting click');
@@ -145,9 +151,27 @@
       return;
     }
     adSkipInitialized = true;
-    const observer = new MutationObserver(clickSkipButton);
-    observer.observe(document, { childList: true, subtree: true, attributes: true });
-    setInterval(clickSkipButton, 1000);
+
+    const trySetup = () => {
+      const player = document.querySelector('.html5-video-player');
+      const video = document.querySelector('video');
+      if (!player || !video) {
+        return false;
+      }
+
+      const observer = new MutationObserver(clickSkipButton);
+      observer.observe(player, { childList: true, subtree: true, attributes: true });
+      setInterval(clickSkipButton, 1000);
+      return true;
+    };
+
+    if (!trySetup()) {
+      const interval = setInterval(() => {
+        if (trySetup()) {
+          clearInterval(interval);
+        }
+      }, 1000);
+    }
   }
 
   function setupAdSpeed(adDelay) {


### PR DESCRIPTION
## Summary
- avoid polling for skip button if no video element is found
- set up ad skip observers only when a player is available
- clarify README about how ad skipping waits for a video element

## Testing
- `node -e "const fs=require('fs'); new Function(fs.readFileSync('content.js','utf8'));"`

------
https://chatgpt.com/codex/tasks/task_e_6844164d82a48325bc3bd0ce8a20f0d0