### PR TITLE
Add configurable skip method option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ Load the `CanDoYouTube` folder as an unpacked extension in Chrome and navigate t
 - `s` – increase speed by 0.25×
 - `q` – reset speed to 1×
 - `w` – set speed to a custom value (default 4×)
-- `e` – skip ads when the Skip button is available (also moves a simulated mouse pointer to the button)
-- Skip Ads – on YouTube the extension automatically moves a simulated pointer to the "Skip" button and clicks it whenever it appears. The ad-skipping logic now waits until a video element is present before activating so the home page no longer triggers continuous scanning.
+- `e` – manually trigger the currently selected Skip Ad method
+- Skip Ads – on YouTube the extension automatically presses the Skip button using the chosen method whenever it appears. The ad-skipping logic now waits until a video element is present before activating so the home page no longer triggers continuous scanning.
 
 Whenever you adjust the rate, a small overlay briefly shows the current
 playback speed on the page so you can confirm the setting. Detailed debug logs
 are also written to the browser console when keys are pressed or when the
 extension searches for and interacts with the Skip button.
 
-Open the extension options to configure the value for the `w` key, set how long the extension waits before speeding up ads, and manage the list of allowed sites. Settings are stored using `chrome.storage.sync` so they persist between browser sessions.
+Open the extension options to configure the value for the `w` key, set how long the extension waits before speeding up ads, choose how the Skip button is pressed, and manage the list of allowed sites. Settings are stored using `chrome.storage.sync` so they persist between browser sessions.
 
 ## Files
 

--- a/options.html
+++ b/options.html
@@ -20,6 +20,14 @@
     <input type="number" id="adDelay" step="0.1" min="0" />
   </label>
   <label>
+    Skip button method:
+    <select id="skipMethod">
+      <option value="pointer">Pointer events</option>
+      <option value="click">Element.click()</option>
+      <option value="fast-forward">Fast-forward then click</option>
+    </select>
+  </label>
+  <label>
     Allowed sites (comma separated domains):
     <input type="text" id="sites" />
   </label>

--- a/options.js
+++ b/options.js
@@ -1,13 +1,15 @@
 const DEFAULT_SITES = ['youtube.com'];
 const DEFAULT_W_SPEED = 4;
 const DEFAULT_AD_DELAY = 2;
+const DEFAULT_SKIP_METHOD = 'pointer';
 
 function loadOptions() {
-  chrome.storage.sync.get(['allowedSites', 'wSpeed', 'adDelay'], (data) => {
+  chrome.storage.sync.get(['allowedSites', 'wSpeed', 'adDelay', 'skipMethod'], (data) => {
     document.getElementById('wSpeed').value = typeof data.wSpeed === 'number' ? data.wSpeed : DEFAULT_W_SPEED;
     const sites = (data.allowedSites || DEFAULT_SITES).join(', ');
     document.getElementById('sites').value = sites;
     document.getElementById('adDelay').value = typeof data.adDelay === 'number' ? data.adDelay : DEFAULT_AD_DELAY;
+    document.getElementById('skipMethod').value = data.skipMethod || DEFAULT_SKIP_METHOD;
   });
 }
 
@@ -16,8 +18,9 @@ function saveOptions() {
   const adDelay = parseFloat(document.getElementById('adDelay').value) || DEFAULT_AD_DELAY;
   const sitesInput = document.getElementById('sites').value.trim();
   const allowedSites = sitesInput ? sitesInput.split(/\s*,\s*/).filter(Boolean) : DEFAULT_SITES;
+  const skipMethod = document.getElementById('skipMethod').value || DEFAULT_SKIP_METHOD;
 
-  chrome.storage.sync.set({ wSpeed, allowedSites, adDelay }, () => {
+  chrome.storage.sync.set({ wSpeed, allowedSites, adDelay, skipMethod }, () => {
     const status = document.getElementById('status');
     status.textContent = 'Options saved.';
     setTimeout(() => { status.textContent = ''; }, 1000);


### PR DESCRIPTION
## Summary
- add `skipMethod` option for how to click the YouTube Skip Ad button
- implement methods: pointer events, direct click, or fast‑forward + click
- expose setting on Options page and persist via storage
- document new option

## Testing
- `node --check content.js`
- `node --check options.js`
- `npm test` *(fails: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68453c11ac608325b9eebeced0c19164