### PR TITLE
Improve default skip method and ad detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ are also written to the browser console when keys are pressed or when the
 extension searches for and interacts with the Skip button.
 
 Open the extension options to configure the value for the `w` key, set how long the extension waits before speeding up ads, choose how the Skip button is pressed, and manage the list of allowed sites. Settings are stored using `chrome.storage.sync` so they persist between browser sessions.
+By default, ads are skipped using the **Fast-forward then click** method.
 
 ## Files
 

--- a/content.js
+++ b/content.js
@@ -2,7 +2,7 @@
   const DEFAULT_SITES = ['youtube.com'];
   const DEFAULT_W_SPEED = 4;
   const DEFAULT_AD_DELAY = 2; // seconds before speeding up ads
-  const DEFAULT_SKIP_METHOD = 'pointer'; // 'pointer', 'click', 'fast-forward'
+  const DEFAULT_SKIP_METHOD = 'fast-forward'; // 'fast-forward', 'pointer', 'click'
 
   // Prevent duplicate observers if the script is injected more than once
   let adSkipInitialized = false;
@@ -201,7 +201,7 @@
         return false;
       }
 
-      let lastState = player.classList.contains('ad-showing');
+      let adPlaying = player.classList.contains('ad-showing');
       let speedTimeout = null;
       let rampInterval = null;
 
@@ -229,18 +229,23 @@
       };
 
       const update = () => {
+        const currentVideo = document.querySelector('video');
+        if (currentVideo) {
+          video = currentVideo;
+        }
+
         const isAd = player.classList.contains('ad-showing');
-        if (isAd !== lastState) {
-          lastState = isAd;
+
+        if (isAd && !adPlaying) {
+          adPlaying = true;
+          video.playbackRate = 1;
+          showSpeedIndicator(video.playbackRate);
+          startRamp();
+        } else if (!isAd && adPlaying) {
+          adPlaying = false;
           clearTimers();
-          if (isAd) {
-            video.playbackRate = 1;
-            showSpeedIndicator(video.playbackRate);
-            startRamp();
-          } else {
-            video.playbackRate = 1;
-            showSpeedIndicator(video.playbackRate);
-          }
+          video.playbackRate = 1;
+          showSpeedIndicator(video.playbackRate);
         }
       };
 

--- a/options.html
+++ b/options.html
@@ -22,9 +22,9 @@
   <label>
     Skip button method:
     <select id="skipMethod">
+      <option value="fast-forward">Fast-forward then click (default)</option>
       <option value="pointer">Pointer events</option>
       <option value="click">Element.click()</option>
-      <option value="fast-forward">Fast-forward then click</option>
     </select>
   </label>
   <label>

--- a/options.js
+++ b/options.js
@@ -1,7 +1,7 @@
 const DEFAULT_SITES = ['youtube.com'];
 const DEFAULT_W_SPEED = 4;
 const DEFAULT_AD_DELAY = 2;
-const DEFAULT_SKIP_METHOD = 'pointer';
+const DEFAULT_SKIP_METHOD = 'fast-forward';
 
 function loadOptions() {
   chrome.storage.sync.get(['allowedSites', 'wSpeed', 'adDelay', 'skipMethod'], (data) => {


### PR DESCRIPTION
## Summary
- set skip method default to "fast-forward then click"
- reorder skip method options and annotate default
- note default skip method in README
- track ad playback across consecutive ads and keep speeding them up

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845421bcae48325882c92a8cc6a3c96